### PR TITLE
feature: 동시성 문제의 해결을 분산락으로 변경

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,11 +26,13 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'com.querydsl:querydsl-jpa:5.0.0'
 	implementation 'com.querydsl:querydsl-apt:5.0.0'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation ('it.ozimov:embedded-redis:0.7.3') { exclude group: "org.slf4j", module: "slf4j-simple" }
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'com.querydsl:querydsl-apt:5.0.0'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.17.7'
 	implementation ('it.ozimov:embedded-redis:0.7.3') { exclude group: "org.slf4j", module: "slf4j-simple" }
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/backend/src/main/java/com/woowacourse/momo/global/config/EmbeddedRedisConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/config/EmbeddedRedisConfiguration.java
@@ -1,0 +1,33 @@
+package com.woowacourse.momo.global.config;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import redis.embedded.RedisServer;
+
+@Profile("local")
+@Configuration
+public class EmbeddedRedisConfiguration {
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void redisServer() {
+        redisServer = new RedisServer(redisPort);
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/global/exception/exception/GlobalErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/exception/GlobalErrorCode.java
@@ -12,6 +12,9 @@ public enum GlobalErrorCode implements ErrorCode {
 
     MAX_UPLOAD_SIZE_FILE_ERROR(400, "MAX_UPLOAD_SIZE_FILE", "요청한 파일의 크기가 제한된 크기보다 큽니다."),
 
+    LOCK_ACQUISITION_FAILED_ERROR(400, "LOCK_ACQUISITION_FAILED_ERROR", "Lock 획득을 실패했습니다."),
+    LOCK_INTERRUPTED_ERROR(400, "LOCK_INTERRUPTED_ERROR", "Lock 획득 과정에서 오류가 발생했습니다."),
+
     VALIDATION_ERROR(400, "VALIDATION_001", "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(500, "SERVER_001", "내부 서버 오류입니다."),
     ;

--- a/backend/src/main/java/com/woowacourse/momo/group/service/ParticipateService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/ParticipateService.java
@@ -12,6 +12,7 @@ import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.service.MemberFindService;
 import com.woowacourse.momo.member.service.dto.response.MemberResponse;
 import com.woowacourse.momo.member.service.dto.response.MemberResponseAssembler;
+import com.woowacourse.momo.support.distributionlock.DistributionLock;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -21,9 +22,10 @@ public class ParticipateService {
     private final MemberFindService memberFindService;
     private final GroupFindService groupFindService;
 
+    @DistributionLock(key = "#groupId")
     @Transactional
     public void participate(Long groupId, Long memberId) {
-        Group group = groupFindService.findByIdForUpdate(groupId);
+        Group group = groupFindService.findGroup(groupId);
         Member member = memberFindService.findMember(memberId);
 
         group.participate(member);

--- a/backend/src/main/java/com/woowacourse/momo/group/service/ParticipateService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/ParticipateService.java
@@ -15,7 +15,6 @@ import com.woowacourse.momo.member.service.dto.response.MemberResponseAssembler;
 import com.woowacourse.momo.support.distributionlock.DistributionLock;
 
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 @Service
 public class ParticipateService {
 
@@ -23,7 +22,6 @@ public class ParticipateService {
     private final GroupFindService groupFindService;
 
     @DistributionLock(key = "#groupId")
-    @Transactional
     public void participate(Long groupId, Long memberId) {
         Group group = groupFindService.findGroup(groupId);
         Member member = memberFindService.findMember(memberId);
@@ -31,6 +29,7 @@ public class ParticipateService {
         group.participate(member);
     }
 
+    @Transactional(readOnly = true)
     public List<MemberResponse> findParticipants(Long groupId) {
         Group group = groupFindService.findGroup(groupId);
         List<Member> participants = group.getParticipants();

--- a/backend/src/main/java/com/woowacourse/momo/support/distributionlock/CustomSpringELParser.java
+++ b/backend/src/main/java/com/woowacourse/momo/support/distributionlock/CustomSpringELParser.java
@@ -1,0 +1,20 @@
+package com.woowacourse.momo.support.distributionlock;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringELParser {
+
+    public static Object getDynamicValue(String methodName, String[] parameterNames, Object[] args,
+                                         String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return methodName + "-" + parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/support/distributionlock/DistributionLock.java
+++ b/backend/src/main/java/com/woowacourse/momo/support/distributionlock/DistributionLock.java
@@ -1,0 +1,20 @@
+package com.woowacourse.momo.support.distributionlock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributionLock {
+
+    String key();
+
+    long waitTime() default 5L;
+
+    long leaseTime() default 2L;
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+}

--- a/backend/src/main/java/com/woowacourse/momo/support/distributionlock/DistributionLockAop.java
+++ b/backend/src/main/java/com/woowacourse/momo/support/distributionlock/DistributionLockAop.java
@@ -24,6 +24,7 @@ public class DistributionLockAop {
     private static final String LOCK_PREFIX = "LOCK: ";
 
     private final RedissonClient redissonClient;
+    private final TransactionGeneratorAop transactionGeneratorAop;
 
     @Around("@annotation(com.woowacourse.momo.support.distributionlock.DistributionLock)")
     public Object lock(ProceedingJoinPoint joinPoint) throws Throwable {
@@ -40,7 +41,7 @@ public class DistributionLockAop {
                 throw new MomoException(GlobalErrorCode.LOCK_ACQUISITION_FAILED_ERROR);
             }
             log.info("lock - " + key);
-            return joinPoint.proceed();
+            return transactionGeneratorAop.proceed(joinPoint);
         } catch (InterruptedException e) {
             log.error(e.getMessage());
             throw new MomoException(GlobalErrorCode.LOCK_INTERRUPTED_ERROR);

--- a/backend/src/main/java/com/woowacourse/momo/support/distributionlock/DistributionLockAop.java
+++ b/backend/src/main/java/com/woowacourse/momo/support/distributionlock/DistributionLockAop.java
@@ -1,0 +1,50 @@
+package com.woowacourse.momo.support.distributionlock;
+
+import java.lang.reflect.Method;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Aspect
+@RequiredArgsConstructor
+@Slf4j
+public class DistributionLockAop {
+    private static final String LOCK_PREFIX = "LOCK: ";
+
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(com.woowacourse.momo.support.distributionlock.DistributionLock)")
+    public Object lock(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        Method method = methodSignature.getMethod();
+        DistributionLock distributionLock = method.getAnnotation(DistributionLock.class);
+
+        String key = LOCK_PREFIX + CustomSpringELParser.getDynamicValue(methodSignature.getName(),
+                methodSignature.getParameterNames(), joinPoint.getArgs(), distributionLock.key());
+
+        RLock lock = redissonClient.getLock(key);
+        try {
+            if (!lock.tryLock(distributionLock.waitTime(), distributionLock.leaseTime(), distributionLock.timeUnit())) {
+                // TODO: MomoException 으로 변경할 것
+                throw new RuntimeException("Lock 획득을 실패했습니다");
+            }
+            log.info("lock - " + key);
+            return joinPoint.proceed();
+        } catch (InterruptedException e) {
+            log.error(e.getMessage());
+            throw new RuntimeException(e);
+        } finally {
+            log.info("unlock - " + key);
+            lock.unlock();
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/support/distributionlock/DistributionLockAop.java
+++ b/backend/src/main/java/com/woowacourse/momo/support/distributionlock/DistributionLockAop.java
@@ -32,7 +32,7 @@ public class DistributionLockAop {
         Method method = methodSignature.getMethod();
         DistributionLock distributionLock = method.getAnnotation(DistributionLock.class);
 
-        String key = LOCK_PREFIX + CustomSpringELParser.getDynamicValue(methodSignature.getName(),
+        String key = LOCK_PREFIX + DistributionLockKeyGenerator.generate(methodSignature.getName(),
                 methodSignature.getParameterNames(), joinPoint.getArgs(), distributionLock.key());
 
         RLock lock = redissonClient.getLock(key);

--- a/backend/src/main/java/com/woowacourse/momo/support/distributionlock/DistributionLockAop.java
+++ b/backend/src/main/java/com/woowacourse/momo/support/distributionlock/DistributionLockAop.java
@@ -13,6 +13,9 @@ import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
+import com.woowacourse.momo.global.exception.exception.MomoException;
+
 @Component
 @Aspect
 @RequiredArgsConstructor
@@ -34,14 +37,13 @@ public class DistributionLockAop {
         RLock lock = redissonClient.getLock(key);
         try {
             if (!lock.tryLock(distributionLock.waitTime(), distributionLock.leaseTime(), distributionLock.timeUnit())) {
-                // TODO: MomoException 으로 변경할 것
-                throw new RuntimeException("Lock 획득을 실패했습니다");
+                throw new MomoException(GlobalErrorCode.LOCK_ACQUISITION_FAILED_ERROR);
             }
             log.info("lock - " + key);
             return joinPoint.proceed();
         } catch (InterruptedException e) {
             log.error(e.getMessage());
-            throw new RuntimeException(e);
+            throw new MomoException(GlobalErrorCode.LOCK_INTERRUPTED_ERROR);
         } finally {
             log.info("unlock - " + key);
             lock.unlock();

--- a/backend/src/main/java/com/woowacourse/momo/support/distributionlock/DistributionLockKeyGenerator.java
+++ b/backend/src/main/java/com/woowacourse/momo/support/distributionlock/DistributionLockKeyGenerator.java
@@ -4,10 +4,10 @@ import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
-public class CustomSpringELParser {
+public class DistributionLockKeyGenerator {
 
-    public static Object getDynamicValue(String methodName, String[] parameterNames, Object[] args,
-                                         String key) {
+    public static Object generate(String methodName, String[] parameterNames, Object[] args,
+                                  String key) {
         ExpressionParser parser = new SpelExpressionParser();
         StandardEvaluationContext context = new StandardEvaluationContext();
 

--- a/backend/src/main/java/com/woowacourse/momo/support/distributionlock/TransactionGeneratorAop.java
+++ b/backend/src/main/java/com/woowacourse/momo/support/distributionlock/TransactionGeneratorAop.java
@@ -1,0 +1,15 @@
+package com.woowacourse.momo.support.distributionlock;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class TransactionGeneratorAop {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/momo/global/config/EmbeddedRedisConfiguration.java
+++ b/backend/src/test/java/com/woowacourse/momo/global/config/EmbeddedRedisConfiguration.java
@@ -1,0 +1,86 @@
+package com.woowacourse.momo.global.config;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import redis.embedded.RedisServer;
+
+@Profile("test")
+@Configuration
+public class EmbeddedRedisConfiguration {
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void redisServer() throws IOException {
+        int port = isRedisRunning() ? findAvailablePort() : redisPort;
+        redisServer = new RedisServer(port);
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+
+    /**
+     * Embedded Redis가 현재 실행중인지 확인
+     */
+    private boolean isRedisRunning() throws IOException {
+        return isRunning(executeGrepProcessCommand(redisPort));
+    }
+
+    /**
+     * 현재 PC/서버에서 사용가능한 포트 조회
+     */
+    public int findAvailablePort() throws IOException {
+        for (int port = 10000; port <= 65535; port++) {
+            Process process = executeGrepProcessCommand(port);
+            if (!isRunning(process)) {
+                return port;
+            }
+        }
+
+        throw new IllegalArgumentException("Not Found Available port: 10000 ~ 65535");
+    }
+
+    /**
+     * 해당 port를 사용중인 프로세스 확인하는 sh 실행
+     */
+    private Process executeGrepProcessCommand(int port) throws IOException {
+        String command = String.format("netstat -nat | grep LISTEN|grep %d", port);
+        String[] shell = {"/bin/sh", "-c", command};
+        return Runtime.getRuntime().exec(shell);
+    }
+
+    /**
+     * 해당 Process가 현재 실행중인지 확인
+     */
+    private boolean isRunning(Process process) {
+        String line;
+        StringBuilder pidInfo = new StringBuilder();
+
+        try (BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            while ((line = input.readLine()) != null) {
+                pidInfo.append(line);
+            }
+
+        } catch (Exception e) {
+        }
+
+        return !pidInfo.toString().isEmpty();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/momo/group/service/GroupSearchServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/GroupSearchServiceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,6 +57,7 @@ class GroupSearchServiceTest {
     private final MemberRepository memberRepository;
     private final FavoriteRepository favoriteRepository;
     private final ImageProvider imageProvider;
+    private final CacheManager cacheManager;
 
     private Member host;
     private Group group1;
@@ -67,6 +69,8 @@ class GroupSearchServiceTest {
 
     @BeforeEach
     void setUp() {
+        cacheManager.getCache("Groups").clear();
+        cacheManager.getCache("Group").clear();
         host = memberRepository.save(MOMO.toMember());
         group1 = groupRepository.save(constructGroup("모모의 스터디", host, STUDY, 5, 이틀후_23시_59분까지));
         favoriteRepository.save(new Favorite(group1.getId(), host.getId()));

--- a/backend/src/test/java/com/woowacourse/momo/group/service/ParticipateServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/ParticipateServiceConcurrencyTest.java
@@ -1,0 +1,91 @@
+package com.woowacourse.momo.group.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+
+import static com.woowacourse.momo.fixture.GroupFixture.MOMO_STUDY;
+import static com.woowacourse.momo.fixture.MemberFixture.MOMO;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.jdbc.Sql;
+
+import lombok.RequiredArgsConstructor;
+
+import com.woowacourse.momo.auth.support.SHA256Encoder;
+import com.woowacourse.momo.group.domain.GroupRepository;
+import com.woowacourse.momo.member.domain.Member;
+import com.woowacourse.momo.member.domain.MemberRepository;
+import com.woowacourse.momo.member.domain.Password;
+import com.woowacourse.momo.member.domain.UserId;
+import com.woowacourse.momo.member.domain.UserName;
+
+@Sql(value = "classpath:init.sql", executionPhase = BEFORE_TEST_METHOD)
+@Sql(value = "classpath:truncate.sql", executionPhase = AFTER_TEST_METHOD)
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+@SpringBootTest
+class ParticipateServiceConcurrencyTest {
+
+    private final ParticipateService participateService;
+    private final GroupRepository groupRepository;
+    private final MemberRepository memberRepository;
+
+    private Member host;
+
+    @BeforeEach
+    void setUp() {
+        this.host = memberRepository.save(MOMO.toMember());
+    }
+
+    @DisplayName("모임 참여 동시 요청이 올 경우에도 정원을 넘어선 인원이 모임에 참여할 수 없다")
+    @Test
+    void participateConcurrencyTest() throws InterruptedException {
+        int capacity = 3;
+        int numOfParticipants = 50;
+        long groupId = groupRepository.save(
+                MOMO_STUDY.builder()
+                        .capacity(capacity)
+                        .toGroup(host)
+        ).getId();
+
+        List<Long> participantIds = new ArrayList<>();
+        for (int i = 0; i < numOfParticipants; i++) {
+            Member savedMember = memberRepository.save(
+                    new Member(UserId.momo("user" + i),
+                            Password.encrypt("User123!", new SHA256Encoder()),
+                            UserName.from("user" + i)));
+            participantIds.add(savedMember.getId());
+        }
+
+        CountDownLatch latch = new CountDownLatch(numOfParticipants);
+        ExecutorService executor = Executors.newFixedThreadPool(numOfParticipants);
+
+        for (Long participantId : participantIds) {
+            executor.submit(() -> {
+                try {
+                    participateService.participate(groupId, participantId);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        executor.shutdown();
+        latch.await();
+
+        long actual = participateService.findParticipants(groupId).size();
+
+        assertThat(actual).isEqualTo(capacity);
+    }
+}

--- a/backend/src/test/resources/security/application-datasource.yml
+++ b/backend/src/test/resources/security/application-datasource.yml
@@ -11,4 +11,4 @@ spring:
     host: localhost
     port: 6379
   cache:
-    type: none
+    type: redis


### PR DESCRIPTION
## ✨ Issue
- #3 

## 작업 내용
- Local과 Test 환경에서 사용할 EmbeddedRedis 설정 추가
- 테스트: 모임 참여하기 동시성 테스트 추가
- Redisson을 사용해 모임 참여하기의 동시성 문제를 분산락으로 해결
- 분산락을 얻은 이후 Lock 내부에서 트랜잭션의 실행과 Commit이 실행되어 데이터 정합성을 보장하도록 개선
- 테스트: @Transactional의 전파속성을 Required_new로 설정하며 테스트 내에서 실행되는 새로운 트랜잭션에서 데이터를 읽어오지 못하는 문제 해결