### PR TITLE
fix: 모임 목록 조회 쿼리에서 발생하는 GroupBy관련 이슈 해결

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
@@ -184,7 +184,7 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
                 participant.count().intValue().add(host),
                 group.closedEarly,
                 group.calendar.deadline.value,
-                groupImage.imageName
+                groupImage.imageName.max()
         );
     }
 


### PR DESCRIPTION
## ✨ 관련 Issue
- #9 

## 📝 작업 내용
문제를 해결하는 여러 방법 중에서 조회하려는 imageName을 집계함수를 통해 특정 데이터로 추출할 수 있도록 하는 방법을 통해 문제를 해결하였다. 

group과 image 테이블은 이미 groupId로 조인이 이루어지며 논리적으로 동일한 group은 동일한 image를 가르키고 있기에 한 개의 데이터만 추출할 수 있는 집계 함수 중 하나인 `MAX`를 통해 해결하였다.


## 👍 해결 결과
과거 문제가 발생했던 요청이 올바른 조회를 할 수 있게 됐다.
<img width="699" alt="image" src="https://github.com/Seongwon97/momo-improved/assets/57744251/7995f791-cb2c-4ba9-b99e-28f0118fadf2">
